### PR TITLE
Fixed Git replacement

### DIFF
--- a/editor.user.js
+++ b/editor.user.js
@@ -292,7 +292,7 @@ var main = function() {
         },
         git: {
           expr:  /(^|\s)(git|GIT)(\s|$)/gm,
-          replacement: "$1Git$2",
+          replacement: "$1Git$3",
           reason: "Git is the proper capitalization"
         },
         harddisk: {


### PR DESCRIPTION
I had accidentally used `$2`, but should have used `$3`. With `$2`, it was creating something like `GitGIT` instead of the desired `Git ` when replacing `GIT`.