### PR TITLE
Fixed word boundary for GitHub

### DIFF
--- a/editor.user.js
+++ b/editor.user.js
@@ -301,7 +301,7 @@ var main = function() {
           reason: "Hard disk is the proper capitalization"
         },
         github: {
-          expr:  /\b([gG]ithub|GITHUB)(\s|$)/gm,
+          expr:  /\b([gG]ithub|GITHUB)\b(\S|)(?!\S)/gm,
           replacement: "GitHub$2",
           reason: "GitHub is the proper capitalization"
         }


### PR DESCRIPTION
Please see https://regex101.com/r/dA0fL9/4 for an example. This should probably be applied to many of the other replacements as well.

I've noticed the issue that the "Fix me" button does not cover cases where the word in question (java, GIT, github, ...) is used right before some punctuation, e.g.

> I don't like java.
> When using GITHUB, can I...?
> How can I delete all content from git?

In these cases, the previous regex didn't capture the word, since `\s` does not match the punctuation.

In the proposed change for `GitHub`, I've changed this to the following:

* A word boundary `\b`
* A non-whitespace `\S` (for the punctuation) or anything
* A negative lookahead to cover the case like `github.com` to make sure that the punctuation is not followed by a non-whitespace character

This is pretty complex, but it works for the examples I have listed in https://regex101.com/r/dA0fL9/4

Let me know if this looks good to you...