### PR TITLE
Window.scrollTo() requires two arguments

### DIFF
--- a/editor.user.js
+++ b/editor.user.js
@@ -706,7 +706,7 @@ var main = function() {
                 if (App.globals.lastSelectedElement) {
                     App.globals.lastSelectedElement.focus();
                 } else {
-                    window.scrollTo(0);
+                    window.scrollTo(0,0);
                 }
             }, 0);
         }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo This was causing up to 39 errors in the console upon submitting the edit.